### PR TITLE
Adjust 'SetPlayer' view if user is host or not

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -17,7 +17,7 @@ function Home() {
       <p><em>Do you have what it takes to make it
       out alive?</em></p>
       <section className="menu">
-        <Link className="menu-opt" to={`/set-player?game=${game}`}>
+        <Link className="menu-opt" to={`/set-player?game=${game}/host/`}>
           <button className="admin-button">New Game</button>
         </Link>
         <form className="menu-opt">
@@ -29,8 +29,7 @@ function Home() {
           />
           <Link
             onClick={event => (!game) ? event.preventDefault() : null}
-            to={`/set-player?game=${game}`}
-          >
+            to={`/set-player?game=${game}`}>
             <input
               className="admin-button"
               type="submit"

--- a/src/components/SetPlayer.js
+++ b/src/components/SetPlayer.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import queryString from 'query-string'
-import { Link } from 'react-router-dom'
+// import queryString from 'query-string'
+import { Link, useLocation } from 'react-router-dom'
 import { useState, useEffect } from 'react'
 import io from 'socket.io-client'
 
@@ -22,11 +22,10 @@ function SetPlayer({ location }) {
     } else {
       setName(event.target.value)
 
-      const game = location.search.substring(6)
-      console.log("location.search", game)
+      const game = location.search.substring(6, 10)
       setGame(game)
-
-      console.log("name", name, "game", game)
+      console.log('name: ', name, 'game: ', game)
+      console.log('users: ', users)
       socket = io(ENDPOINT)
 
       // Pass callback to execute after socket.emit
@@ -46,12 +45,13 @@ function SetPlayer({ location }) {
   }
 
   useEffect(() => {
+    console.log(location.search.substring(10))
     socket = io(ENDPOINT)
     socket.on('roomData', ({ users }) => {
       console.log(users)
       setUsers(users)
     });
-  }, []);
+  }, [location]);
 
   return (
     <section className="Set-Player">
@@ -71,6 +71,11 @@ function SetPlayer({ location }) {
         </Link>
       </form>
       <PlayerList users={users} />
+      {
+        (location.search.substring(10))
+        ? <button className="admin-button">We're ready!</button>
+        : <></>
+      }
     </section>
   )
 


### PR DESCRIPTION
Add extra tag to set-player search path to designate a host
Use ternary to display button only if the user is the host
Adjust 'substring' function in 'joinUsertoGame' accordingly (add second
parameter to 'substring' so it will not pick up the host tag as part of
the game ID)